### PR TITLE
feat(gateway): add deploy_gateway_name and deploy_gateway_fqdn

### DIFF
--- a/src/grid_client/deployment.rs
+++ b/src/grid_client/deployment.rs
@@ -704,6 +704,28 @@ fn workload_challenge(out: &mut String, workload: &DeployWorkload) -> Result<(),
                 out.push_str(&gpu);
             }
         }
+        zos::GATEWAY_NAME_PROXY_TYPE => {
+            let data: GatewayNameProxyData =
+                serde_json::from_value(workload.data.clone()).map_err(GridError::from)?;
+            out.push_str(&data.name);
+            for backend in &data.backends {
+                out.push_str(backend);
+            }
+            write!(out, "{}", data.tls_passthrough)
+                .map_err(|err| GridError::backend(err.to_string()))?;
+            out.push_str(&data.network);
+        }
+        zos::GATEWAY_FQDN_PROXY_TYPE => {
+            let data: GatewayFqdnProxyData =
+                serde_json::from_value(workload.data.clone()).map_err(GridError::from)?;
+            out.push_str(&data.fqdn);
+            for backend in &data.backends {
+                out.push_str(backend);
+            }
+            write!(out, "{}", data.tls_passthrough)
+                .map_err(|err| GridError::backend(err.to_string()))?;
+            out.push_str(&data.network);
+        }
         other => {
             return Err(GridError::validation(format!(
                 "unsupported live workload type {other}"

--- a/src/grid_client/deployment.rs
+++ b/src/grid_client/deployment.rs
@@ -705,26 +705,30 @@ fn workload_challenge(out: &mut String, workload: &DeployWorkload) -> Result<(),
             }
         }
         zos::GATEWAY_NAME_PROXY_TYPE => {
+            // Matches the canonical Go ZOS implementation in
+            // pkg/gridtypes/zos/gw_name.go: Name → TLSPassthrough → Backends.
+            // `network` is NOT included in the challenge — ZOS rejects the
+            // signature otherwise.
             let data: GatewayNameProxyData =
                 serde_json::from_value(workload.data.clone()).map_err(GridError::from)?;
             out.push_str(&data.name);
+            write!(out, "{}", data.tls_passthrough)
+                .map_err(|err| GridError::backend(err.to_string()))?;
             for backend in &data.backends {
                 out.push_str(backend);
             }
-            write!(out, "{}", data.tls_passthrough)
-                .map_err(|err| GridError::backend(err.to_string()))?;
-            out.push_str(&data.network);
         }
         zos::GATEWAY_FQDN_PROXY_TYPE => {
+            // Matches the canonical Go ZOS implementation in
+            // pkg/gridtypes/zos/gw_fqdn.go: FQDN → TLSPassthrough → Backends.
             let data: GatewayFqdnProxyData =
                 serde_json::from_value(workload.data.clone()).map_err(GridError::from)?;
             out.push_str(&data.fqdn);
+            write!(out, "{}", data.tls_passthrough)
+                .map_err(|err| GridError::backend(err.to_string()))?;
             for backend in &data.backends {
                 out.push_str(backend);
             }
-            write!(out, "{}", data.tls_passthrough)
-                .map_err(|err| GridError::backend(err.to_string()))?;
-            out.push_str(&data.network);
         }
         other => {
             return Err(GridError::validation(format!(

--- a/src/grid_client/deployment.rs
+++ b/src/grid_client/deployment.rs
@@ -720,6 +720,71 @@ pub(crate) fn public_ip_count(workloads: &[DeployWorkload]) -> u32 {
         .count() as u32
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GatewayNameProxyData {
+    name: String,
+    tls_passthrough: bool,
+    backends: Vec<String>,
+    #[serde(skip_serializing_if = "String::is_empty", default)]
+    network: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GatewayFqdnProxyData {
+    fqdn: String,
+    tls_passthrough: bool,
+    backends: Vec<String>,
+    #[serde(skip_serializing_if = "String::is_empty", default)]
+    network: String,
+}
+
+pub(crate) fn build_gateway_name_proxy(
+    name: &str,
+    backends: &[String],
+    tls_passthrough: bool,
+    network: Option<&str>,
+) -> DeployWorkload {
+    DeployWorkload {
+        version: 0,
+        name: name.to_string(),
+        workload_type: zos::GATEWAY_NAME_PROXY_TYPE.to_string(),
+        data: serde_json::to_value(GatewayNameProxyData {
+            name: name.to_string(),
+            tls_passthrough,
+            backends: backends.to_vec(),
+            network: network.unwrap_or("").to_string(),
+        })
+        .unwrap_or_default(),
+        metadata: String::new(),
+        description: "gateway-name-proxy".to_string(),
+        result: empty_result_data(),
+    }
+}
+
+pub(crate) fn build_gateway_fqdn_proxy(
+    name: &str,
+    fqdn: &str,
+    backends: &[String],
+    tls_passthrough: bool,
+    network: Option<&str>,
+) -> DeployWorkload {
+    DeployWorkload {
+        version: 0,
+        name: name.to_string(),
+        workload_type: zos::GATEWAY_FQDN_PROXY_TYPE.to_string(),
+        data: serde_json::to_value(GatewayFqdnProxyData {
+            fqdn: fqdn.to_string(),
+            tls_passthrough,
+            backends: backends.to_vec(),
+            network: network.unwrap_or("").to_string(),
+        })
+        .unwrap_or_default(),
+        metadata: String::new(),
+        description: "gateway-fqdn-proxy".to_string(),
+        result: empty_result_data(),
+    }
+}
+
 pub(crate) fn empty_result_data() -> zos::ResultData {
     zos::ResultData {
         created: 0,

--- a/src/grid_client/mod.rs
+++ b/src/grid_client/mod.rs
@@ -44,16 +44,17 @@ use crate::{error::GridError, workloads, zos};
 mod deployment;
 mod types;
 pub(crate) use deployment::{
-    DeployDeployment, build_network, build_network_light, build_vm, build_vm_light,
-    deployment_hash_hex, public_ip_count, sign_deployment, validate_vm_light_request,
-    validate_vm_request,
+    DeployDeployment, build_gateway_fqdn_proxy, build_gateway_name_proxy, build_network,
+    build_network_light, build_vm, build_vm_light, deployment_hash_hex, public_ip_count,
+    sign_deployment, validate_vm_light_request, validate_vm_request,
 };
 pub use types::{
     DeploymentOutcome, ExistingNetworkSpec, FullNetworkSpec, FullNetworkSpecBuilder,
-    FullNetworkTarget, NetworkLightSpec, NetworkLightSpecBuilder, NetworkTarget, NodePlacement,
-    NodeRequirements, NodeRequirementsBuilder, VmDeployment, VmDeploymentBuilder,
-    VmLightDeployment, VmLightDeploymentBuilder, VmLightMount, VmLightSpec, VmLightSpecBuilder,
-    VmSpec, VmSpecBuilder, VolumeMountSpec,
+    FullNetworkTarget, GatewayDeploymentOutcome, GatewayFqdnDeployment, GatewayNameDeployment,
+    NetworkLightSpec, NetworkLightSpecBuilder, NetworkTarget, NodePlacement, NodeRequirements,
+    NodeRequirementsBuilder, VmDeployment, VmDeploymentBuilder, VmLightDeployment,
+    VmLightDeploymentBuilder, VmLightMount, VmLightSpec, VmLightSpecBuilder, VmSpec, VmSpecBuilder,
+    VolumeMountSpec,
 };
 
 const RMB_SCHEMA: &str = "application/json";
@@ -712,6 +713,171 @@ impl GridClient {
         .await
     }
 
+    pub async fn deploy_gateway_name(
+        &self,
+        request: GatewayNameDeployment,
+    ) -> Result<GatewayDeploymentOutcome, GridError> {
+        validate_gateway_name_request(&request)?;
+        self.ensure_twin_relay().await?;
+        trace_step(format!(
+            "deploy gateway-name-proxy '{}' on node {} (twin {})",
+            request.name, request.node_id, request.node_twin_id
+        ));
+
+        // 1. Register the subdomain on-chain.
+        submit_create_name_contract(&self.chain, &self.signer, &request.name)
+            .await
+            .map_err(|err| {
+                GridError::backend(format!("create name contract '{}': {err}", request.name))
+            })?;
+        let name_contract_id = self.wait_for_name_contract(&request.name).await?;
+        trace_step(format!("name contract id {name_contract_id}"));
+
+        // 2. Build the deployment workload + sign + hash.
+        let workload = build_gateway_name_proxy(
+            &request.name,
+            &request.backends,
+            request.tls_passthrough,
+            request.network.as_deref(),
+        );
+        let metadata = deployment_metadata(&request.name, "gateway-name-proxy", &request.name);
+        let mut deployment =
+            DeployDeployment::new(self.identity.twin_id, metadata, vec![workload]);
+        sign_deployment(&mut deployment, self.identity.twin_id, &self.signer)?;
+        let hash = deployment_hash_hex(&deployment)?;
+        debug_dump("gateway-name", &deployment, &hash);
+
+        // 3. Create the node contract (anchors the deployment).
+        submit_create_node_contract(
+            &self.chain,
+            &self.signer,
+            request.node_id,
+            &deployment.metadata,
+            &hash,
+            0,
+        )
+        .await
+        .map_err(|err| {
+            GridError::backend(format!("create gateway-name node contract: {err}"))
+        })?;
+        let contract_id = self.wait_for_contract(request.node_id, &hash).await?;
+        deployment.contract_id = contract_id;
+
+        // 4. Push to the gateway node over RMB and wait for the workload to come up.
+        self.deploy_and_confirm(request.node_twin_id, &deployment)
+            .await
+            .map_err(|err| GridError::backend(format!("deploy gateway-name over RMB: {err}")))?;
+        self.wait_for_workloads(request.node_twin_id, contract_id)
+            .await
+            .map_err(|err| GridError::backend(format!("wait gateway-name workloads: {err}")))?;
+
+        // 5. Read back the workload to extract the assigned FQDN.
+        let state = self
+            .rmb_call::<_, serde_json::Value>(
+                request.node_twin_id,
+                "zos.deployment.get",
+                &json!({ "contract_id": contract_id }),
+                None,
+            )
+            .await
+            .map_err(|err| {
+                GridError::backend(format!("load gateway-name deployment from node: {err}"))
+            })?;
+        let workloads = extract_workloads(state)?;
+        let fqdn = gateway_fqdn_from_workloads(&workloads, &request.name);
+
+        Ok(GatewayDeploymentOutcome {
+            node_id: request.node_id,
+            node_twin_id: request.node_twin_id,
+            name: request.name,
+            fqdn,
+            contract_id,
+            name_contract_id,
+        })
+    }
+
+    pub async fn deploy_gateway_fqdn(
+        &self,
+        request: GatewayFqdnDeployment,
+    ) -> Result<GatewayDeploymentOutcome, GridError> {
+        validate_gateway_fqdn_request(&request)?;
+        self.ensure_twin_relay().await?;
+        trace_step(format!(
+            "deploy gateway-fqdn-proxy '{}' (fqdn {}) on node {} (twin {})",
+            request.name, request.fqdn, request.node_id, request.node_twin_id
+        ));
+
+        // Build deployment workload + sign + hash. No name contract for FQDN
+        // gateways — the operator owns the DNS record themselves.
+        let workload = build_gateway_fqdn_proxy(
+            &request.name,
+            &request.fqdn,
+            &request.backends,
+            request.tls_passthrough,
+            request.network.as_deref(),
+        );
+        let metadata = deployment_metadata(&request.name, "gateway-fqdn-proxy", &request.name);
+        let mut deployment =
+            DeployDeployment::new(self.identity.twin_id, metadata, vec![workload]);
+        sign_deployment(&mut deployment, self.identity.twin_id, &self.signer)?;
+        let hash = deployment_hash_hex(&deployment)?;
+        debug_dump("gateway-fqdn", &deployment, &hash);
+
+        submit_create_node_contract(
+            &self.chain,
+            &self.signer,
+            request.node_id,
+            &deployment.metadata,
+            &hash,
+            0,
+        )
+        .await
+        .map_err(|err| {
+            GridError::backend(format!("create gateway-fqdn node contract: {err}"))
+        })?;
+        let contract_id = self.wait_for_contract(request.node_id, &hash).await?;
+        deployment.contract_id = contract_id;
+
+        self.deploy_and_confirm(request.node_twin_id, &deployment)
+            .await
+            .map_err(|err| GridError::backend(format!("deploy gateway-fqdn over RMB: {err}")))?;
+        self.wait_for_workloads(request.node_twin_id, contract_id)
+            .await
+            .map_err(|err| GridError::backend(format!("wait gateway-fqdn workloads: {err}")))?;
+
+        Ok(GatewayDeploymentOutcome {
+            node_id: request.node_id,
+            node_twin_id: request.node_twin_id,
+            name: request.name,
+            fqdn: request.fqdn,
+            contract_id,
+            name_contract_id: 0,
+        })
+    }
+
+    /// Cancel both the deployment contract and (for name proxies) the name
+    /// contract associated with a previous gateway deploy.
+    pub async fn cancel_gateway(
+        &self,
+        outcome: &GatewayDeploymentOutcome,
+    ) -> Result<(), GridError> {
+        if outcome.contract_id != 0 {
+            let _ = self
+                .rmb_call::<_, serde_json::Value>(
+                    outcome.node_twin_id,
+                    "zos.deployment.delete",
+                    &json!({ "contract_id": outcome.contract_id }),
+                    None,
+                )
+                .await;
+            self.cancel_contract(outcome.contract_id).await?;
+        }
+        if outcome.name_contract_id != 0 {
+            self.cancel_contract(outcome.name_contract_id).await?;
+        }
+        Ok(())
+    }
+
     pub fn debug_rmb_token(&self) -> Result<String, GridError> {
         jwt_token(&self.signer, self.identity.twin_id, None, 60)
     }
@@ -1209,6 +1375,45 @@ impl GridClient {
             if Instant::now() >= deadline {
                 return Err(GridError::backend(format!(
                     "timed out waiting for contract {deployment_hash}"
+                )));
+            }
+            sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    /// Poll grid_proxy for a freshly-created name contract owned by this
+    /// twin. We don't get the contract id back from the extrinsic submission,
+    /// so the proxy is the cheapest place to look it up.
+    async fn wait_for_name_contract(&self, name: &str) -> Result<u64, GridError> {
+        trace_step(format!(
+            "waiting for name contract '{name}' owned by twin {}",
+            self.identity.twin_id
+        ));
+        let deadline = Instant::now() + Duration::from_secs(45);
+        loop {
+            let response = self
+                .http
+                .get(format!("{}/contracts", self.grid_proxy_url))
+                .query(&[
+                    ("twin_id", self.identity.twin_id.to_string()),
+                    ("type", "name".to_string()),
+                    ("state", "Created".to_string()),
+                    ("name", name.to_string()),
+                ])
+                .send()
+                .await
+                .map_err(|err| GridError::backend(err.to_string()))?;
+            if response.status() == StatusCode::OK {
+                let contracts: Vec<ProxyContract> =
+                    parse_json_response(response, "grid proxy /contracts (name)").await?;
+                if let Some(contract) = contracts.into_iter().next() {
+                    trace_step(format!("found name contract {}", contract.contract_id));
+                    return Ok(contract.contract_id);
+                }
+            }
+            if Instant::now() >= deadline {
+                return Err(GridError::backend(format!(
+                    "timed out waiting for name contract '{name}'"
                 )));
             }
             sleep(Duration::from_secs(1)).await;
@@ -1761,6 +1966,79 @@ fn extract_ip_value(value: Option<&serde_json::Value>) -> Option<String> {
             .map(ToOwned::to_owned),
         _ => None,
     }
+}
+
+fn validate_gateway_name_request(req: &GatewayNameDeployment) -> Result<(), GridError> {
+    if req.node_id == 0 {
+        return Err(GridError::validation("gateway node_id must be >0"));
+    }
+    if req.node_twin_id == 0 {
+        return Err(GridError::validation("gateway node_twin_id must be >0"));
+    }
+    if req.name.trim().is_empty() {
+        return Err(GridError::validation("gateway name must not be empty"));
+    }
+    if req.backends.is_empty() {
+        return Err(GridError::validation(
+            "gateway must have at least one backend",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_gateway_fqdn_request(req: &GatewayFqdnDeployment) -> Result<(), GridError> {
+    if req.node_id == 0 {
+        return Err(GridError::validation("gateway node_id must be >0"));
+    }
+    if req.node_twin_id == 0 {
+        return Err(GridError::validation("gateway node_twin_id must be >0"));
+    }
+    if req.name.trim().is_empty() {
+        return Err(GridError::validation("gateway name must not be empty"));
+    }
+    if req.fqdn.trim().is_empty() {
+        return Err(GridError::validation("gateway fqdn must not be empty"));
+    }
+    if req.backends.is_empty() {
+        return Err(GridError::validation(
+            "gateway must have at least one backend",
+        ));
+    }
+    Ok(())
+}
+
+fn gateway_fqdn_from_workloads(workloads: &[zos::Workload], name: &str) -> String {
+    workloads
+        .iter()
+        .find(|workload| workload.name == name)
+        .map(|workload| {
+            let result = &workload.result.data;
+            result
+                .get("fqdn")
+                .or_else(|| result.get("FQDN"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string()
+        })
+        .unwrap_or_default()
+}
+
+async fn submit_create_name_contract(
+    chain: &OnlineClient<PolkadotConfig>,
+    signer: &Keypair,
+    name: &str,
+) -> Result<(), GridError> {
+    let tx = dynamic::tx(
+        "SmartContractModule",
+        "create_name_contract",
+        vec![Value::from_bytes(name.as_bytes())],
+    );
+    let progress = chain
+        .tx()
+        .sign_and_submit_then_watch_default(&tx, signer)
+        .await
+        .map_err(|err| GridError::backend(err.to_string()))?;
+    wait_for_finalized(progress).await
 }
 
 async fn submit_create_node_contract(

--- a/src/grid_client/mod.rs
+++ b/src/grid_client/mod.rs
@@ -741,8 +741,7 @@ impl GridClient {
             request.network.as_deref(),
         );
         let metadata = deployment_metadata(&request.name, "gateway-name-proxy", &request.name);
-        let mut deployment =
-            DeployDeployment::new(self.identity.twin_id, metadata, vec![workload]);
+        let mut deployment = DeployDeployment::new(self.identity.twin_id, metadata, vec![workload]);
         sign_deployment(&mut deployment, self.identity.twin_id, &self.signer)?;
         let hash = deployment_hash_hex(&deployment)?;
         debug_dump("gateway-name", &deployment, &hash);
@@ -757,9 +756,7 @@ impl GridClient {
             0,
         )
         .await
-        .map_err(|err| {
-            GridError::backend(format!("create gateway-name node contract: {err}"))
-        })?;
+        .map_err(|err| GridError::backend(format!("create gateway-name node contract: {err}")))?;
         let contract_id = self.wait_for_contract(request.node_id, &hash).await?;
         deployment.contract_id = contract_id;
 
@@ -817,8 +814,7 @@ impl GridClient {
             request.network.as_deref(),
         );
         let metadata = deployment_metadata(&request.name, "gateway-fqdn-proxy", &request.name);
-        let mut deployment =
-            DeployDeployment::new(self.identity.twin_id, metadata, vec![workload]);
+        let mut deployment = DeployDeployment::new(self.identity.twin_id, metadata, vec![workload]);
         sign_deployment(&mut deployment, self.identity.twin_id, &self.signer)?;
         let hash = deployment_hash_hex(&deployment)?;
         debug_dump("gateway-fqdn", &deployment, &hash);
@@ -832,9 +828,7 @@ impl GridClient {
             0,
         )
         .await
-        .map_err(|err| {
-            GridError::backend(format!("create gateway-fqdn node contract: {err}"))
-        })?;
+        .map_err(|err| GridError::backend(format!("create gateway-fqdn node contract: {err}")))?;
         let contract_id = self.wait_for_contract(request.node_id, &hash).await?;
         deployment.contract_id = contract_id;
 

--- a/src/grid_client/types.rs
+++ b/src/grid_client/types.rs
@@ -640,3 +640,66 @@ impl VmSpecBuilder {
         self.spec
     }
 }
+
+// ── Gateway deployment requests / outcome ────────────────────────────────────
+
+/// Request describing a `gateway-name-proxy` deployment.
+///
+/// `name` is the subdomain label registered as an on-chain "name contract";
+/// the gateway node appends its own zone and returns the resulting public
+/// `fqdn` in [`GatewayDeploymentOutcome::fqdn`].
+#[derive(Debug, Clone)]
+pub struct GatewayNameDeployment {
+    /// Target gateway node (must support gateway workloads).
+    pub node_id: u32,
+    /// Twin id of the gateway node — needed for RMB.
+    pub node_twin_id: u32,
+    /// Subdomain label to register (e.g. `"myapp"` → `myapp.<gateway-zone>`).
+    pub name: String,
+    /// HTTP(S) backend URLs the gateway will proxy to.
+    pub backends: Vec<String>,
+    /// When true, TLS terminates at the backend (the gateway just forwards).
+    pub tls_passthrough: bool,
+    /// Optional Mycelium / WireGuard network name to dial backends through.
+    pub network: Option<String>,
+}
+
+/// Request describing a `gateway-fqdn-proxy` deployment.
+///
+/// `fqdn` must be a domain you already own and have pointed at the gateway
+/// node's public IP — the gateway terminates TLS for it.
+#[derive(Debug, Clone)]
+pub struct GatewayFqdnDeployment {
+    /// Target gateway node.
+    pub node_id: u32,
+    /// Twin id of the gateway node.
+    pub node_twin_id: u32,
+    /// Workload name (used as the on-node identifier).
+    pub name: String,
+    /// Fully-qualified domain the gateway will serve.
+    pub fqdn: String,
+    /// HTTP(S) backend URLs the gateway will proxy to.
+    pub backends: Vec<String>,
+    /// When true, TLS terminates at the backend (the gateway just forwards).
+    pub tls_passthrough: bool,
+    /// Optional Mycelium / WireGuard network name to dial backends through.
+    pub network: Option<String>,
+}
+
+/// Result of a successful gateway deployment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayDeploymentOutcome {
+    pub node_id: u32,
+    pub node_twin_id: u32,
+    /// Workload name on the node.
+    pub name: String,
+    /// Public FQDN serving traffic. For `name-proxy` this is filled from the
+    /// workload result (zone appended by the gateway); for `fqdn-proxy` it
+    /// matches the requested fqdn.
+    pub fqdn: String,
+    /// Substrate contract for the deployment workload.
+    pub contract_id: u64,
+    /// Substrate contract for the on-chain name registration. Zero for
+    /// `fqdn-proxy` (no name registration step).
+    pub name_contract_id: u64,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,9 @@ pub use calculator::Calculator;
 pub use error::GridError;
 pub use grid_client::{
     DEV_NETWORK, DeploymentOutcome, ExistingNetworkSpec, FullNetworkSpec, FullNetworkSpecBuilder,
-    FullNetworkTarget, GridClient, GridClientConfig, GridClientConfigBuilder, MAIN_NETWORK,
-    NetworkLightSpec, NetworkLightSpecBuilder, NetworkTarget, NodePlacement, NodeRequirements,
+    FullNetworkTarget, GatewayDeploymentOutcome, GatewayFqdnDeployment, GatewayNameDeployment,
+    GridClient, GridClientConfig, GridClientConfigBuilder, MAIN_NETWORK, NetworkLightSpec,
+    NetworkLightSpecBuilder, NetworkTarget, NodePlacement, NodeRequirements,
     NodeRequirementsBuilder, QA_NETWORK, TEST_NETWORK, VmDeployment, VmDeploymentBuilder,
     VmLightDeployment, VmLightDeploymentBuilder, VmLightMount, VmLightSpec, VmLightSpecBuilder,
     VmSpec, VmSpecBuilder, VolumeMountSpec,

--- a/src/workloads.rs
+++ b/src/workloads.rs
@@ -436,8 +436,16 @@ impl Deployment {
                     .map(|q| q.zos_workload())
                     .collect::<Result<Vec<_>, _>>()?,
             )
-            .chain(self.gateway_name_proxies.iter().map(GatewayNameProxy::zos_workload))
-            .chain(self.gateway_fqdn_proxies.iter().map(GatewayFQDNProxy::zos_workload))
+            .chain(
+                self.gateway_name_proxies
+                    .iter()
+                    .map(GatewayNameProxy::zos_workload),
+            )
+            .chain(
+                self.gateway_fqdn_proxies
+                    .iter()
+                    .map(GatewayFQDNProxy::zos_workload),
+            )
             .collect();
 
         Ok(zos::Deployment {
@@ -1951,12 +1959,8 @@ mod tests {
 
     #[test]
     fn gateway_name_proxy_roundtrips_through_workload() {
-        let mut spec = GatewayNameProxy::new(
-            42,
-            "myapp",
-            vec!["http://10.0.0.1:8080".to_string()],
-            true,
-        );
+        let mut spec =
+            GatewayNameProxy::new(42, "myapp", vec!["http://10.0.0.1:8080".to_string()], true);
         spec.network = "mynet".to_string();
         let workload = spec.zos_workload();
         assert_eq!(workload.workload_type, zos::GATEWAY_NAME_PROXY_TYPE);

--- a/src/workloads.rs
+++ b/src/workloads.rs
@@ -322,6 +322,10 @@ pub struct Deployment {
     pub vms_light: Vec<VMLight>,
     pub qsfs: Vec<QSFS>,
     pub volumes: Vec<Volume>,
+    #[serde(default)]
+    pub gateway_name_proxies: Vec<GatewayNameProxy>,
+    #[serde(default)]
+    pub gateway_fqdn_proxies: Vec<GatewayFQDNProxy>,
     pub node_deployment_id: HashMap<u32, u64>,
     pub contract_id: u64,
     pub ip_range: String,
@@ -354,6 +358,8 @@ impl Deployment {
             vms_light,
             qsfs,
             volumes,
+            gateway_name_proxies: Vec::new(),
+            gateway_fqdn_proxies: Vec::new(),
             node_deployment_id: HashMap::new(),
             contract_id: 0,
             ip_range: String::new(),
@@ -387,6 +393,12 @@ impl Deployment {
         }
         for v in &self.volumes {
             v.validate()?;
+        }
+        for g in &self.gateway_name_proxies {
+            g.validate()?;
+        }
+        for g in &self.gateway_fqdn_proxies {
+            g.validate()?;
         }
         Ok(())
     }
@@ -424,6 +436,8 @@ impl Deployment {
                     .map(|q| q.zos_workload())
                     .collect::<Result<Vec<_>, _>>()?,
             )
+            .chain(self.gateway_name_proxies.iter().map(GatewayNameProxy::zos_workload))
+            .chain(self.gateway_fqdn_proxies.iter().map(GatewayFQDNProxy::zos_workload))
             .collect();
 
         Ok(zos::Deployment {
@@ -893,6 +907,152 @@ impl GatewayFQDNProxy {
             contract_id: 0,
             node_deployment_id: HashMap::new(),
         })
+    }
+}
+
+// ── Gateway forward conversion (struct → zos::Workload) ──────────────────────
+//
+// `from_workload` parses an existing on-chain workload back into a typed
+// struct; `zos_workload` is its inverse — used at deploy time to construct
+// the workload that goes into a deployment.
+
+impl GatewayNameProxy {
+    /// Construct a new gateway-name-proxy spec.
+    ///
+    /// `name` is the unregistered subdomain label (e.g. `"myapp"`); the
+    /// gateway node appends its own zone to produce the public FQDN (returned
+    /// in the workload result data).
+    pub fn new(
+        node_id: u32,
+        name: impl Into<String>,
+        backends: Vec<String>,
+        tls_passthrough: bool,
+    ) -> Self {
+        Self {
+            node_id,
+            name: name.into(),
+            backends,
+            tls_passthrough,
+            network: String::new(),
+            description: String::new(),
+            solution_type: String::new(),
+            node_deployment_id: HashMap::new(),
+            fqdn: String::new(),
+            name_contract_id: 0,
+            contract_id: 0,
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), GridError> {
+        if self.node_id == 0 {
+            return Err(GridError::validation("gateway node_id must be >0"));
+        }
+        if self.name.trim().is_empty() {
+            return Err(GridError::validation("gateway name must not be empty"));
+        }
+        if self.backends.is_empty() {
+            return Err(GridError::validation(
+                "gateway must have at least one backend",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Build the on-chain workload representation for this gateway spec.
+    pub fn zos_workload(&self) -> zos::Workload {
+        let mut data = serde_json::json!({
+            "name": self.name,
+            "tls_passthrough": self.tls_passthrough,
+            "backends": self.backends,
+        });
+        if !self.network.is_empty() {
+            data["network"] = serde_json::Value::String(self.network.clone());
+        }
+        let description = if self.description.is_empty() {
+            "gateway-name-proxy".to_string()
+        } else {
+            self.description.clone()
+        };
+        zos::Workload {
+            version: 0,
+            name: self.name.clone(),
+            workload_type: zos::GATEWAY_NAME_PROXY_TYPE.to_string(),
+            data,
+            metadata: String::new(),
+            description,
+            result: zos::ResultData::default(),
+        }
+    }
+}
+
+impl GatewayFQDNProxy {
+    /// Construct a new gateway-fqdn-proxy spec.
+    ///
+    /// `name` is the workload name; `fqdn` is the public domain the user
+    /// already owns and has pointed at the gateway node.
+    pub fn new(
+        node_id: u32,
+        name: impl Into<String>,
+        fqdn: impl Into<String>,
+        backends: Vec<String>,
+        tls_passthrough: bool,
+    ) -> Self {
+        Self {
+            node_id,
+            backends,
+            fqdn: fqdn.into(),
+            name: name.into(),
+            tls_passthrough,
+            network: String::new(),
+            description: String::new(),
+            solution_type: String::new(),
+            contract_id: 0,
+            node_deployment_id: HashMap::new(),
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), GridError> {
+        if self.node_id == 0 {
+            return Err(GridError::validation("gateway node_id must be >0"));
+        }
+        if self.name.trim().is_empty() {
+            return Err(GridError::validation("gateway name must not be empty"));
+        }
+        if self.fqdn.trim().is_empty() {
+            return Err(GridError::validation("gateway fqdn must not be empty"));
+        }
+        if self.backends.is_empty() {
+            return Err(GridError::validation(
+                "gateway must have at least one backend",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Build the on-chain workload representation for this gateway spec.
+    pub fn zos_workload(&self) -> zos::Workload {
+        let mut data = serde_json::json!({
+            "fqdn": self.fqdn,
+            "tls_passthrough": self.tls_passthrough,
+            "backends": self.backends,
+        });
+        if !self.network.is_empty() {
+            data["network"] = serde_json::Value::String(self.network.clone());
+        }
+        let description = if self.description.is_empty() {
+            "gateway-fqdn-proxy".to_string()
+        } else {
+            self.description.clone()
+        };
+        zos::Workload {
+            version: 0,
+            name: self.name.clone(),
+            workload_type: zos::GATEWAY_FQDN_PROXY_TYPE.to_string(),
+            data,
+            metadata: String::new(),
+            description,
+            result: zos::ResultData::default(),
+        }
     }
 }
 
@@ -1787,5 +1947,69 @@ mod tests {
         assert_eq!(vm.flist_checksum, "checksum-vm2");
         assert_eq!(vm.mycelium_ip, "mycelium-vm2");
         assert_eq!(vm.console_url, "https://console-2.example");
+    }
+
+    #[test]
+    fn gateway_name_proxy_roundtrips_through_workload() {
+        let mut spec = GatewayNameProxy::new(
+            42,
+            "myapp",
+            vec!["http://10.0.0.1:8080".to_string()],
+            true,
+        );
+        spec.network = "mynet".to_string();
+        let workload = spec.zos_workload();
+        assert_eq!(workload.workload_type, zos::GATEWAY_NAME_PROXY_TYPE);
+        assert_eq!(workload.name, "myapp");
+        assert_eq!(workload.data["name"], "myapp");
+        assert_eq!(workload.data["tls_passthrough"], true);
+        assert_eq!(workload.data["backends"][0], "http://10.0.0.1:8080");
+        assert_eq!(workload.data["network"], "mynet");
+
+        let parsed = GatewayNameProxy::from_workload(&workload).expect("parse");
+        assert_eq!(parsed.name, "myapp");
+        assert_eq!(parsed.backends, spec.backends);
+        assert!(parsed.tls_passthrough);
+        assert_eq!(parsed.network, "mynet");
+    }
+
+    #[test]
+    fn gateway_fqdn_proxy_roundtrips_through_workload() {
+        let spec = GatewayFQDNProxy::new(
+            7,
+            "myapp",
+            "myapp.example.com",
+            vec!["https://10.0.0.1:443".to_string()],
+            false,
+        );
+        let workload = spec.zos_workload();
+        assert_eq!(workload.workload_type, zos::GATEWAY_FQDN_PROXY_TYPE);
+        assert_eq!(workload.name, "myapp");
+        assert_eq!(workload.data["fqdn"], "myapp.example.com");
+        assert_eq!(workload.data["tls_passthrough"], false);
+        assert_eq!(workload.data["backends"][0], "https://10.0.0.1:443");
+        // network is empty → omitted from JSON
+        assert!(workload.data.get("network").is_none());
+
+        let parsed = GatewayFQDNProxy::from_workload(&workload).expect("parse");
+        assert_eq!(parsed.name, "myapp");
+        assert_eq!(parsed.fqdn, "myapp.example.com");
+        assert_eq!(parsed.backends, spec.backends);
+        assert!(!parsed.tls_passthrough);
+        assert!(parsed.network.is_empty());
+    }
+
+    #[test]
+    fn gateway_name_proxy_validates_required_fields() {
+        let mut spec = GatewayNameProxy::new(1, "ok", vec!["http://x".to_string()], false);
+        assert!(spec.validate().is_ok());
+        spec.node_id = 0;
+        assert!(spec.validate().is_err());
+
+        let mut spec = GatewayNameProxy::new(1, "", vec!["http://x".to_string()], false);
+        assert!(spec.validate().is_err());
+        spec.name = "ok".to_string();
+        spec.backends.clear();
+        assert!(spec.validate().is_err());
     }
 }


### PR DESCRIPTION
Closes the gap that prevented Rust callers from deploying ZOS
gateway-name-proxy and gateway-fqdn-proxy workloads. The structs
existed already but only with from_workload() — there was no path to
push one onto the chain.

What's added:

- `GatewayNameProxy::new() / validate() / zos_workload()` and the same
  for `GatewayFQDNProxy` — forward conversion mirroring the existing
  from_workload() parsers.

- `workloads::Deployment` now carries `gateway_name_proxies` and
  `gateway_fqdn_proxies` Vecs, included in `zos_deployment()` and
  `validate()`.

- `grid_client::build_gateway_name_proxy` / `build_gateway_fqdn_proxy`
  internal builders producing DeployWorkload with the correct JSON
  data shape ZOS expects (`name`/`fqdn`, `tls_passthrough`,
  `backends`, optional `network`).

- Public request types `GatewayNameDeployment` / `GatewayFqdnDeployment`
  and the result type `GatewayDeploymentOutcome`.

- `GridClient::deploy_gateway_name(req)` — submits a substrate name
  contract, polls grid_proxy for its id, then creates a node contract,
  RMB-deploys the workload, waits for `ok`, and reads back the
  assigned FQDN.

- `GridClient::deploy_gateway_fqdn(req)` — skips the name-contract step
  (user owns the domain) and follows the rest of the flow.

- `GridClient::cancel_gateway(outcome)` — convenience that deletes the
  RMB deployment and cancels both contracts.

- Three new unit tests covering the workload round-trip and validation.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>Closes the gap that prevented Rust callers from deploying ZOS
gateway-name-proxy and gateway-fqdn-proxy workloads. The structs
existed already but only with from_workload() — there was no path to
push one onto the chain.

What's added:

- `GatewayNameProxy::new() / validate() / zos_workload()` and the same
  for `GatewayFQDNProxy` — forward conversion mirroring the existing
  from_workload() parsers.

- `workloads::Deployment` now carries `gateway_name_proxies` and
  `gateway_fqdn_proxies` Vecs, included in `zos_deployment()` and
  `validate()`.

- `grid_client::build_gateway_name_proxy` / `build_gateway_fqdn_proxy`
  internal builders producing DeployWorkload with the correct JSON
  data shape ZOS expects (`name`/`fqdn`, `tls_passthrough`,
  `backends`, optional `network`).

- Public request types `GatewayNameDeployment` / `GatewayFqdnDeployment`
  and the result type `GatewayDeploymentOutcome`.

- `GridClient::deploy_gateway_name(req)` — submits a substrate name
  contract, polls grid_proxy for its id, then creates a node contract,
  RMB-deploys the workload, waits for `ok`, and reads back the
  assigned FQDN.

- `GridClient::deploy_gateway_fqdn(req)` — skips the name-contract step
  (user owns the domain) and follows the rest of the flow.

- `GridClient::cancel_gateway(outcome)` — convenience that deletes the
  RMB deployment and cancels both contracts.

- Three new unit tests covering the workload round-trip and validation.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>Closes the gap that prevented Rust callers from deploying ZOS
gateway-name-proxy and gateway-fqdn-proxy workloads. The structs
existed already but only with from_workload() — there was no path to
push one onto the chain.

What's added:

- `GatewayNameProxy::new() / validate() / zos_workload()` and the same
  for `GatewayFQDNProxy` — forward conversion mirroring the existing
  from_workload() parsers.

- `workloads::Deployment` now carries `gateway_name_proxies` and
  `gateway_fqdn_proxies` Vecs, included in `zos_deployment()` and
  `validate()`.

- `grid_client::build_gateway_name_proxy` / `build_gateway_fqdn_proxy`
  internal builders producing DeployWorkload with the correct JSON
  data shape ZOS expects (`name`/`fqdn`, `tls_passthrough`,
  `backends`, optional `network`).

- Public request types `GatewayNameDeployment` / `GatewayFqdnDeployment`
  and the result type `GatewayDeploymentOutcome`.

- `GridClient::deploy_gateway_name(req)` — submits a substrate name
  contract, polls grid_proxy for its id, then creates a node contract,
  RMB-deploys the workload, waits for `ok`, and reads back the
  assigned FQDN.

- `GridClient::deploy_gateway_fqdn(req)` — skips the name-contract step
  (user owns the domain) and follows the rest of the flow.

- `GridClient::cancel_gateway(outcome)` — convenience that deletes the
  RMB deployment and cancels both contracts.

- Three new unit tests covering the workload round-trip and validation.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>